### PR TITLE
Add Functionality for Documents on different Drives

### DIFF
--- a/JavaWord.bas
+++ b/JavaWord.bas
@@ -45,7 +45,7 @@ End If
 '   3- Compile .java file
 '   4- Run .java file
 strCmd = "cmd.exe /S /K"
-strCmd = strCmd & "CD " & strDocPath
+strCmd = strCmd & "CD /D " & strDocPath
 strCmd = strCmd & " & set PATH=" & strJavaPath & ";%PATH%"
 strCmd = strCmd & " & javac " & strDocNameExt
 strCmd = strCmd & " & java " & strDocName


### PR DESCRIPTION
When working with a Word file on a different drive, `cd` did change the directory correctly.
